### PR TITLE
Convert dates to pandas datetimes when requesting dataframe

### DIFF
--- a/uk_covid19/api_interface.py
+++ b/uk_covid19/api_interface.py
@@ -88,7 +88,7 @@ class Cov19API:
 
             The output is extracted from the header and is accurate to
             the second.
-            
+
         .. warning::
 
             The ISO-8601 standard requires a ``"Z"`` character to be added
@@ -158,7 +158,7 @@ class Cov19API:
             most other libraries; e.g. ``pandas``. If you wish to parse the
             timestamp using the the ``datetime`` library, make sure that you
             remove the trailing ``"Z"`` character.
-            
+
         Returns
         -------
         str
@@ -567,7 +567,8 @@ class Cov19API:
 
         data = self.get_json()
         df = DataFrame(data["data"])
-
+        if 'date' in df.columns:
+            df['date'] = pd.to_datetime(df['date'])
         return df
 
     def __str__(self):


### PR DESCRIPTION
I'm not sure if you're accepting pull requests, but in case you are here is one!

This parses the date column as a pandas datetime type if present; otherwise the type is just strings, which is not idea for plotting the data or analysing it further.